### PR TITLE
Fix mismatch in IMIS output file name

### DIFF
--- a/functions/05b_probabilistic-analysis_functions.R
+++ b/functions/05b_probabilistic-analysis_functions.R
@@ -13,7 +13,7 @@ f.generate_psa_params <- function(n.sim, seed = 20190220){ # User defined
   ##
   
   ## Load calibrated parameters
-  load("output/03_imis-output.rData")
+  load("output/03_imis-output.RData")
   n.sim <- nrow(m.calib.post)
   set.seed <- seed
   df.psa.params <- data.frame(


### PR DESCRIPTION
There's a mismatch in the IMIS output file names that causes an error when I run a fresh clone of the framework.

The PSA functions have:

https://github.com/DARTH-git/Decision-Modeling-Framework/blob/26cd339f21f2a9a327fffd4724f639a9e2f91d02/functions/05b_probabilistic-analysis_functions.R#L16

But 03_calibration.R saves the output as:
https://github.com/DARTH-git/Decision-Modeling-Framework/blob/ffc8f35903f73f258ee11fad4a81d4a2f2a22185/R/03_calibration.R#L177-L179